### PR TITLE
Revert "Označení pluginu jako zataralý"

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,3 @@
-2016-01-12
- * plugin je zastaraly a nefunkcni
 2015-10-22
  * Oprava parsovani dat - #4
 2015-05-09

--- a/addon.xml
+++ b/addon.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.dmd-czech.prima"
-       name="Prima PLAY (zastaralý)"
-       version="4.0.10"
+       name="Prima PLAY"
+       version="4.0.9"
        provider-name="Jiri Vyhnalek">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.dmd-czech.common" version="1.5.8"/>
-    <import addon="plugin.video.primaplay" version="0.2.1"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
     <provides>video</provides>
@@ -22,6 +21,5 @@
         Plugin pro přehrávání videí z archivu play.iprima.cz
     </description>
     <source>https://github.com/kodi-czsk/plugin.video.dmd-czech.prima</source>
-    <broken>deprecated</broken>
   </extension>
 </addon>


### PR DESCRIPTION
Reverts kodi-czsk/plugin.video.dmd-czech.prima#9

Sorry, ale myslím, že to takto nebude fungovat, protože tento nový doplněk:
<import addon="plugin.video.primaplay" version="0.2.1"/>

není možné nikterak naimportovat, nebude vědět odkud ho vzít, protože není součástí repozitáře KODI CZ/SK.

Navrhuji doplněk přidat do celého repozitáře KODI CZ/SK  a alladinovi udělat přístup pro správu tohoto jeho doplňku.
